### PR TITLE
Disable slave inverter controls by default

### DIFF
--- a/custom_components/lxp_modbus/entity_descriptions/button_types.py
+++ b/custom_components/lxp_modbus/entity_descriptions/button_types.py
@@ -11,6 +11,7 @@ BUTTON_TYPES = [
         "icon": "mdi:restart-alert",
         "enabled": True,
         "visible": True,
+        "master_only": False,
     },
     {
         "name": "Clear Detected Phases",
@@ -21,5 +22,6 @@ BUTTON_TYPES = [
         "press": lambda orig: 0,
         "enabled": True,
         "visible": True,
+        "master_only": False,
     },
 ]

--- a/custom_components/lxp_modbus/entity_descriptions/number_types.py
+++ b/custom_components/lxp_modbus/entity_descriptions/number_types.py
@@ -18,6 +18,7 @@ NUMBER_TYPES = [
         "icon": "mdi:numeric",
         "enabled": False,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Grid Connect Time",
@@ -31,6 +32,7 @@ NUMBER_TYPES = [
         "icon": "mdi:timer-sand",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Grid Reconnect Time",
@@ -44,6 +46,7 @@ NUMBER_TYPES = [
         "icon": "mdi:timer-refresh",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Grid Voltage Low Limit",
@@ -57,6 +60,7 @@ NUMBER_TYPES = [
         "icon": "mdi:arrow-collapse-vertical",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Grid Voltage High Limit",
@@ -70,6 +74,7 @@ NUMBER_TYPES = [
         "icon": "mdi:arrow-expand-vertical",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Grid Frequency Low Limit",
@@ -83,6 +88,7 @@ NUMBER_TYPES = [
         "icon": "mdi:arrow-collapse-horizontal",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Grid Frequency High Limit",
@@ -96,6 +102,7 @@ NUMBER_TYPES = [
         "icon": "mdi:arrow-expand-horizontal",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Max Grid Input Power",
@@ -109,6 +116,7 @@ NUMBER_TYPES = [
         "icon": "mdi:import",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "External CT Power Offset",
@@ -122,6 +130,7 @@ NUMBER_TYPES = [
         "icon": "mdi:plus-minus-variant",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
 
     # --- Power Control ---
@@ -137,6 +146,7 @@ NUMBER_TYPES = [
         "icon": "mdi:brightness-percent",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Power Soft Start Slope",
@@ -150,6 +160,7 @@ NUMBER_TYPES = [
         "icon": "mdi:stairs-up",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Max Backflow Power",
@@ -163,6 +174,7 @@ NUMBER_TYPES = [
         "icon": "mdi:export",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
 
     # --- Charging & Discharging ---
@@ -178,6 +190,7 @@ NUMBER_TYPES = [
         "icon": "mdi:current-ac",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Discharge Current",
@@ -191,6 +204,7 @@ NUMBER_TYPES = [
         "icon": "mdi:current-ac",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "AC Charge Power",
@@ -204,6 +218,7 @@ NUMBER_TYPES = [
         "icon": "mdi:battery-charging",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "AC Charge SOC Limit",
@@ -217,6 +232,7 @@ NUMBER_TYPES = [
         "icon": "mdi:battery-charging-90",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "AC Charge Start Voltage",
@@ -230,6 +246,7 @@ NUMBER_TYPES = [
         "icon": "mdi:battery-arrow-up-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "AC Charge End Voltage",
@@ -243,6 +260,7 @@ NUMBER_TYPES = [
         "icon": "mdi:battery-check-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "AC Charge Start SOC",
@@ -256,6 +274,7 @@ NUMBER_TYPES = [
         "icon": "mdi:battery-arrow-up-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "AC Charge Current from Grid",
@@ -269,6 +288,7 @@ NUMBER_TYPES = [
         "icon": "mdi:current-ac",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "On-Grid Cut-Off SOC",
@@ -282,6 +302,7 @@ NUMBER_TYPES = [
         "icon": "mdi:battery-low",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "On-Grid Cut-Off Voltage",
@@ -295,6 +316,7 @@ NUMBER_TYPES = [
         "icon": "mdi:grid",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Battery Stop Charging SOC",
@@ -308,6 +330,7 @@ NUMBER_TYPES = [
         "icon": "mdi:battery-off",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Battery Stop Charging Voltage",
@@ -321,6 +344,7 @@ NUMBER_TYPES = [
         "icon": "mdi:battery-off-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
 
     # --- EPS (Off-Grid) ---
@@ -336,6 +360,7 @@ NUMBER_TYPES = [
         "icon": "mdi:battery-alert",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
 
     # --- Unmatched/Lead-Acid Battery ---
@@ -351,6 +376,7 @@ NUMBER_TYPES = [
         "icon": "mdi:battery",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Unmatched Battery Nominal Voltage",
@@ -364,6 +390,7 @@ NUMBER_TYPES = [
         "icon": "mdi:battery",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Float Charge Voltage",
@@ -377,6 +404,7 @@ NUMBER_TYPES = [
         "icon": "mdi:battery-plus-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Equalization Interval",
@@ -390,6 +418,7 @@ NUMBER_TYPES = [
         "icon": "mdi:calendar-sync",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Equalization Time",
@@ -403,6 +432,7 @@ NUMBER_TYPES = [
         "icon": "mdi:timer-cog",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Battery Low Voltage Alarm",
@@ -416,6 +446,7 @@ NUMBER_TYPES = [
         "icon": "mdi:battery-alert-variant-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Battery Low Voltage Recovery",
@@ -429,6 +460,7 @@ NUMBER_TYPES = [
         "icon": "mdi:battery-sync-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Battery Low SOC Alarm",
@@ -442,6 +474,7 @@ NUMBER_TYPES = [
         "icon": "mdi:battery-alert-variant-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Battery Low SOC Recovery",
@@ -455,6 +488,7 @@ NUMBER_TYPES = [
         "icon": "mdi:battery-sync-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
 
     # --- Generator ---
@@ -470,6 +504,7 @@ NUMBER_TYPES = [
         "icon": "mdi:engine",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Generator Charge Start Voltage",
@@ -483,6 +518,7 @@ NUMBER_TYPES = [
         "icon": "mdi:engine-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Generator Charge End Voltage",
@@ -496,6 +532,7 @@ NUMBER_TYPES = [
         "icon": "mdi:engine-off-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Generator Charge Start SOC",
@@ -509,6 +546,7 @@ NUMBER_TYPES = [
         "icon": "mdi:engine-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Generator Charge End SOC",
@@ -522,6 +560,7 @@ NUMBER_TYPES = [
         "icon": "mdi:engine-off-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Max Generator Charge Current",
@@ -535,6 +574,7 @@ NUMBER_TYPES = [
         "icon": "mdi:engine",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
 
     # --- Peak Shaving ---
@@ -550,6 +590,7 @@ NUMBER_TYPES = [
         "icon": "mdi:chart-gantt",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Grid Peak Shaving SOC",
@@ -563,6 +604,7 @@ NUMBER_TYPES = [
         "icon": "mdi:chart-gantt",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
 
     # --- Miscellaneous ---
@@ -578,6 +620,7 @@ NUMBER_TYPES = [
         "icon": "mdi:lock",
         "enabled": False,
         "visible": True,
+        "master_only": True,
     },
     
     # --- New Number Entities from 2025-06-14 Documentation ---
@@ -593,6 +636,7 @@ NUMBER_TYPES = [
         "icon": "mdi:percent-box-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Battery Voltage Hysteresis",
@@ -606,6 +650,7 @@ NUMBER_TYPES = [
         "icon": "mdi:volt-box-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "BUS Overvoltage Alarm Point",
@@ -619,6 +664,7 @@ NUMBER_TYPES = [
         "icon": "mdi:bus-alert",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Discharge Recovery SOC Threshold",
@@ -630,12 +676,11 @@ NUMBER_TYPES = [
         "unit": "%",
         "multiplier": 1,
         "icon": "mdi:battery-sync-outline",
-        # Extracts the SOC value from the low byte
         "extract": lambda value: value & 0xFF,
-        # Composes the new value, preserving the high byte (voltage)
         "compose": lambda orig, value: (orig & 0xFF00) | (value & 0xFF),
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Discharge Recovery Volt Threshold",
@@ -647,12 +692,11 @@ NUMBER_TYPES = [
         "unit": "V",
         "multiplier": 10,
         "icon": "mdi:battery-sync-outline",
-        # Extracts the Voltage value from the high byte
         "extract": lambda value: (value >> 8) & 0xFF,
-        # Composes the new value, preserving the low byte (SOC)
         "compose": lambda orig, value: (orig & 0x00FF) | ((value & 0xFF) << 8),
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "WattNode CT1 Amps",
@@ -666,6 +710,7 @@ NUMBER_TYPES = [
         "icon": "mdi:current-ac",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "WattNode CT2 Amps",
@@ -679,6 +724,7 @@ NUMBER_TYPES = [
         "icon": "mdi:current-ac",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "WattNode CT3 Amps",
@@ -692,6 +738,7 @@ NUMBER_TYPES = [
         "icon": "mdi:current-ac",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "NEC 120% Bus Bar Limit",
@@ -705,5 +752,6 @@ NUMBER_TYPES = [
         "icon": "mdi:current-ac",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
 ]

--- a/custom_components/lxp_modbus/entity_descriptions/selectbox_types.py
+++ b/custom_components/lxp_modbus/entity_descriptions/selectbox_types.py
@@ -6,62 +6,66 @@ SELECTBOX_TYPES = [
         "name": "AC Charge Type",
         "register": H_SYSTEM_ENABLE_2,   # 120
         "register_type": "hold",
-        "extract": lambda reg: get_bits(reg, 1, 3),   # Bits 1-3 [cite: 141]
+        "extract": lambda reg: get_bits(reg, 1, 3),
         "compose": lambda orig, value: set_bits(orig, 1, 3, value),
         "options": {
-            0: "Disable", # [cite: 141]
-            1: "According to Time", # [cite: 141]
-            2: "According to Voltage", # [cite: 141]
-            3: "According to SOC", # [cite: 141]
-            4: "According to Voltage and Time", # [cite: 141]
-            5: "According to SOC and Time", # [cite: 141]
+            0: "Disable",
+            1: "According to Time",
+            2: "According to Voltage",
+            3: "According to SOC",
+            4: "According to Voltage and Time",
+            5: "According to SOC and Time",
         },
         "icon": "mdi:battery-charging",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Discharge Control Type",
         "register": H_SYSTEM_ENABLE_2,   # 120
         "register_type": "hold",
-        "extract": lambda reg: get_bits(reg, 4, 2),   # Bits 4-5 [cite: 141]
+        "extract": lambda reg: get_bits(reg, 4, 2),
         "compose": lambda orig, value: set_bits(orig, 4, 2, value),
         "options": {
-            0: "According to Voltage", # [cite: 141]
-            1: "According to SOC", # [cite: 141]
-            2: "According to Both", # [cite: 141]
+            0: "According to Voltage",
+            1: "According to SOC",
+            2: "According to Both",
         },
         "icon": "mdi:battery-arrow-down",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "On-Grid EOD Type",
         "register": H_SYSTEM_ENABLE_2,   # 120
         "register_type": "hold",
-        "extract": lambda reg: get_bits(reg, 6, 1),   # Bit 6 [cite: 141]
+        "extract": lambda reg: get_bits(reg, 6, 1),
         "compose": lambda orig, value: set_bits(orig, 6, 1, value),
         "options": {
-            0: "According to Voltage", # [cite: 141]
-            1: "According to SOC", # [cite: 141]
+            0: "According to Voltage",
+            1: "According to SOC",
         },
         "icon": "mdi:grid",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Generator Charge Type",
         "register": H_SYSTEM_ENABLE_2,   # 120
         "register_type": "hold",
-        "extract": lambda reg: get_bits(reg, 7, 1),   # Bit 7 [cite: 141]
+        "extract": lambda reg: get_bits(reg, 7, 1),
         "compose": lambda orig, value: set_bits(orig, 7, 1, value),
         "options": {
-            0: "According to Battery Voltage", # [cite: 141]
-            1: "According to Battery SOC", # [cite: 141]
+            0: "According to Battery Voltage",
+            1: "According to Battery SOC",
         },
         "icon": "mdi:engine",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "System Type",
@@ -70,15 +74,16 @@ SELECTBOX_TYPES = [
         "extract": lambda reg: reg,
         "compose": lambda orig, value: value,
         "options": {
-            0: "No parallel (single one)", # [cite: 137]
-            1: "Single-phase parallel (primary)", # [cite: 137]
-            2: "Secondary", # [cite: 137]
-            3: "Three phase parallel (Master)", # [cite: 137]
-            4: "2*208 (Master) - for split-phase", # [cite: 137]
+            0: "No parallel (single one)",
+            1: "Single-phase parallel (primary)",
+            2: "Secondary",
+            3: "Three phase parallel (Master)",
+            4: "2*208 (Master) - for split-phase",
         },
         "icon": "mdi:vector-link",
         "enabled": True,
         "visible": True,
+        "master_only": False,
     },
     {
         "name": "Language",
@@ -87,12 +92,13 @@ SELECTBOX_TYPES = [
         "extract": lambda reg: reg,
         "compose": lambda orig, value: value,
         "options": {
-            0: "English", # [cite: 110]
-            1: "German", # [cite: 110]
+            0: "English",
+            1: "German",
         },
         "icon": "mdi:translate",
         "enabled": False,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "PV Input Model",
@@ -101,18 +107,19 @@ SELECTBOX_TYPES = [
         "extract": lambda reg: reg,
         "compose": lambda orig, value: value,
         "options": {
-            0: "No PV", # [cite: 110]
-            1: "PV1 in", # [cite: 110]
-            2: "PV2 in", # [cite: 110]
-            3: "PV3 in", # [cite: 110]
-            4: "PV1 & PV2 in", # [cite: 110]
-            5: "PV1 & PV3 in", # [cite: 110]
-            6: "PV2 & PV3 in", # [cite: 110]
-            7: "PV1 & PV2 & PV3 in", # [cite: 110]
+            0: "No PV",
+            1: "PV1 in",
+            2: "PV2 in",
+            3: "PV3 in",
+            4: "PV1 & PV2 in",
+            5: "PV1 & PV3 in",
+            6: "PV2 & PV3 in",
+            7: "PV1 & PV2 & PV3 in",
         },
         "icon": "mdi:solar-panel",
         "enabled": True,
         "visible": True,
+        "master_only": False,
     },
     {
         "name": "Reactive Power Command Type",
@@ -121,18 +128,19 @@ SELECTBOX_TYPES = [
         "extract": lambda reg: reg,
         "compose": lambda orig, value: value,
         "options": {
-            0: "Unit power factor", # [cite: 124]
-            1: "Fixed PF", # [cite: 124]
-            2: "Default PF curve (Q(P))", # [cite: 124]
-            3: "Custom PF curve", # [cite: 124]
-            4: "Capacitive reactive power percentage", # [cite: 124]
-            5: "Inductive reactive power percentage", # [cite: 124]
-            6: "Q(V) curve", # [cite: 124]
-            7: "Q(V) Dynamic", # [cite: 124]
+            0: "Unit power factor",
+            1: "Fixed PF",
+            2: "Default PF curve (Q(P))",
+            3: "Custom PF curve",
+            4: "Capacitive reactive power percentage",
+            5: "Inductive reactive power percentage",
+            6: "Q(V) curve",
+            7: "Q(V) Dynamic",
         },
         "icon": "mdi:flash",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Output Priority Config",
@@ -141,13 +149,14 @@ SELECTBOX_TYPES = [
         "extract": lambda reg: reg,
         "compose": lambda orig, value: value,
         "options": {
-            0: "Battery First", # [cite: 151]
-            1: "PV First", # [cite: 151]
-            2: "AC First", # [cite: 151]
+            0: "Battery First",
+            1: "PV First",
+            2: "AC First",
         },
         "icon": "mdi:power-plug",
         "enabled": False,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Line Mode",
@@ -156,13 +165,14 @@ SELECTBOX_TYPES = [
         "extract": lambda reg: reg,
         "compose": lambda orig, value: value,
         "options": {
-            0: "APL (Appliance)", # [cite: 151]
-            1: "UPS (Uninterruptible Power Supply)", # [cite: 151]
-            2: "GEN (Generator)", # [cite: 151]
+            0: "APL (Appliance)",
+            1: "UPS (Uninterruptible Power Supply)",
+            2: "GEN (Generator)",
         },
         "icon": "mdi:power-settings",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Grid Type",
@@ -186,34 +196,37 @@ SELECTBOX_TYPES = [
         },
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Smart Load Enable",
         "register": H_FUNCTION_ENABLE_4, # 179
         "register_type": "hold",
-        "extract": lambda reg: get_bits(reg, 13, 1), # Bit 13 [cite: 156]
+        "extract": lambda reg: get_bits(reg, 13, 1),
         "compose": lambda orig, value: set_bits(orig, 13, 1, value),
         "options": {
-            0: "Generator", # [cite: 156]
-            1: "Smart Load", # [cite: 156]
+            0: "Generator",
+            1: "Smart Load",
         },
         "icon": "mdi:home-lightning-bolt",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "LCD Screen Type",
         "register": H_LCD_CONFIG, # 224
         "register_type": "hold",
-        "extract": lambda reg: get_bits(reg, 8, 1), # Bit 8 [cite: 162]
+        "extract": lambda reg: get_bits(reg, 8, 1),
         "compose": lambda orig, value: set_bits(orig, 8, 1, value),
         "options": {
-            0: "Screen 'B' size", # [cite: 162]
-            1: "Screen 'S' size", # [cite: 162]
+            0: "Screen 'B' size",
+            1: "Screen 'S' size",
         },
         "icon": "mdi:monitor",
         "enabled": False,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "EPS Voltage Set",
@@ -231,6 +244,7 @@ SELECTBOX_TYPES = [
         },
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "EPS Frequency Set",
@@ -245,15 +259,14 @@ SELECTBOX_TYPES = [
         },
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Off-grid Composed Phase",
         "register": H_SET_COMPOSED_PHASE,
         "register_type": "hold",
         "icon": "mdi:chart-timeline-variant",
-        # Extracts the value from the lower 8 bits (Bit0-7)
         "extract": lambda value: value & 0xFF,
-        # The user's selection (1, 2, or 3) is written directly to the register
         "compose": lambda orig, value: value,
         "options": {
             1: "R Phase",
@@ -262,5 +275,6 @@ SELECTBOX_TYPES = [
         },
         "enabled": True,
         "visible": True,
+        "master_only": False,
     },
 ]

--- a/custom_components/lxp_modbus/entity_descriptions/switch_types.py
+++ b/custom_components/lxp_modbus/entity_descriptions/switch_types.py
@@ -1,8 +1,6 @@
 from ..constants.hold_registers import *
 from ..utils import get_bits, set_bits
 
-from ..utils import get_bits, set_bits
-
 SWITCH_TYPES = [
     # Register 21: H_FUNCTION_ENABLE_1
     {
@@ -15,6 +13,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Over-Frequency Load Reduction",
@@ -26,6 +25,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "DRMS",
@@ -37,6 +37,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "AC Charging",
@@ -48,6 +49,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Forced Discharge",
@@ -59,6 +61,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     # Register 22: H_FUNCTION_ENABLE_2_AND_PV_START_VOLT
     {
@@ -71,6 +74,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     # Register 110: H_FUNCTION_ENABLE_3
     {
@@ -83,6 +87,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Micro-Grid",
@@ -94,6 +99,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Buzzer",
@@ -105,6 +111,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Green Mode",
@@ -116,6 +123,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Eco Mode",
@@ -127,6 +135,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     # Register 120: H_SYSTEM_ENABLE_2
     {
@@ -139,6 +148,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     # Register 179: H_FUNCTION_ENABLE_4
     {
@@ -151,6 +161,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Grid Peak Shaving",
@@ -162,6 +173,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "AC Coupling",
@@ -173,6 +185,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "PV Arc Detection",
@@ -184,6 +197,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": False,
     },
     {
         "name": "On-Grid Always On",
@@ -195,6 +209,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     # Register 232: H_GRID_PEAK_SHAVING_POWER_1_AND_FUNC_EN
     {
@@ -207,6 +222,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Battery Backup",
@@ -218,6 +234,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Battery Maintenance",
@@ -229,6 +246,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "WattNode CT1 Direction",
@@ -240,6 +258,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "WattNode CT2 Direction",
@@ -251,6 +270,7 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "WattNode CT3 Direction",
@@ -262,5 +282,6 @@ SWITCH_TYPES = [
         "device_class": "switch",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
 ]

--- a/custom_components/lxp_modbus/entity_descriptions/time_types.py
+++ b/custom_components/lxp_modbus/entity_descriptions/time_types.py
@@ -10,6 +10,7 @@ TIME_TYPES = [
         "icon": "mdi:clock-start",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "AC Charging End Time",
@@ -20,6 +21,7 @@ TIME_TYPES = [
         "icon": "mdi:clock-end",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "AC Charging Start Time 1",
@@ -30,6 +32,7 @@ TIME_TYPES = [
         "icon": "mdi:clock-start",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "AC Charging End Time 1",
@@ -40,6 +43,7 @@ TIME_TYPES = [
         "icon": "mdi:clock-end",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "AC Charging Start Time 2",
@@ -50,6 +54,7 @@ TIME_TYPES = [
         "icon": "mdi:clock-start",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "AC Charging End Time 2",
@@ -60,6 +65,7 @@ TIME_TYPES = [
         "icon": "mdi:clock-end",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "AC First Load Start Time",
@@ -70,6 +76,7 @@ TIME_TYPES = [
         "icon": "mdi:clock-start",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "AC First Load End Time",
@@ -80,6 +87,7 @@ TIME_TYPES = [
         "icon": "mdi:clock-end",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "AC First Load Start Time 1",
@@ -90,6 +98,7 @@ TIME_TYPES = [
         "icon": "mdi:clock-start",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "AC First Load End Time 1",
@@ -100,6 +109,7 @@ TIME_TYPES = [
         "icon": "mdi:clock-end",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Peak Shaving Start Time",
@@ -110,6 +120,7 @@ TIME_TYPES = [
         "icon": "mdi:clock-start",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Peak Shaving End Time",
@@ -120,6 +131,7 @@ TIME_TYPES = [
         "icon": "mdi:clock-end",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Peak Shaving Start Time 1",
@@ -130,6 +142,7 @@ TIME_TYPES = [
         "icon": "mdi:clock-start",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Peak Shaving End Time 1",
@@ -140,9 +153,8 @@ TIME_TYPES = [
         "icon": "mdi:clock-end",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
-
-    # --- New Time Entities from 2025-06-14 Documentation ---
     {
         "name": "Generator Start Time",
         "register": H_GEN_START_TIME,
@@ -152,6 +164,7 @@ TIME_TYPES = [
         "icon": "mdi:engine-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Generator End Time",
@@ -162,6 +175,7 @@ TIME_TYPES = [
         "icon": "mdi:engine-off-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Generator Start Time 1",
@@ -172,6 +186,7 @@ TIME_TYPES = [
         "icon": "mdi:engine-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
     {
         "name": "Generator End Time 1",
@@ -182,5 +197,6 @@ TIME_TYPES = [
         "icon": "mdi:engine-off-outline",
         "enabled": True,
         "visible": True,
+        "master_only": True,
     },
 ]


### PR DESCRIPTION
Adds logic to the base entity to automatically disable control entities (numbers, switches, etc.) if the inverter is identified as a slave in a parallel setup.