### PR TITLE
Add get_highest_set_bit utility and update sensor extraction logic.

### DIFF
--- a/custom_components/lxp_modbus/entity_descriptions/sensor_types.py
+++ b/custom_components/lxp_modbus/entity_descriptions/sensor_types.py
@@ -6,7 +6,7 @@ from ..constants.input_registers import *
 from ..constants.fault_codes import FAULT_CODES
 from ..constants.warning_codes import WARNING_CODES
 from ..const import CONF_RATED_POWER
-from ..utils import decode_bitmask_to_string
+from ..utils import decode_bitmask_to_string, get_highest_set_bit
 
 SENSOR_TYPES = [
     # --- Calc  Sensors ---
@@ -792,7 +792,9 @@ SENSOR_TYPES = [
         "icon": "mdi:numeric",
         "enabled": True,
         "visible": True,
-        "extract": lambda registers, entry: (registers.get(I_FAULT_CODE_H, 0) << 16) | registers.get(I_FAULT_CODE_L, 0),
+        "extract": lambda registers, entry: get_highest_set_bit(
+            (registers.get(I_FAULT_CODE_H, 0) << 16) | registers.get(I_FAULT_CODE_L, 0)
+        ),
         "master_only": False,
     },
     {
@@ -816,7 +818,9 @@ SENSOR_TYPES = [
         "icon": "mdi:numeric",
         "enabled": True,
         "visible": True,
-        "extract": lambda registers, entry: (registers.get(I_WARNING_CODE_H, 0) << 16) | registers.get(I_WARNING_CODE_L, 0),
+        "extract": lambda registers, entry: get_highest_set_bit(
+            (registers.get(I_FAULT_CODE_H, 0) << 16) | registers.get(I_FAULT_CODE_L, 0)
+        ),
         "master_only": False,
     },
     {

--- a/custom_components/lxp_modbus/utils.py
+++ b/custom_components/lxp_modbus/utils.py
@@ -60,3 +60,10 @@ def format_firmware_version(hold_registers: dict) -> str | None:
         return f"{fw_string}-{version_string}"
     except Exception:
         return None
+
+def get_highest_set_bit(value: int) -> int | None:
+    """Finds the position of the highest set bit in an integer."""
+    if not isinstance(value, int) or value == 0:
+        return None
+    # Calculate the position of the most significant bit.
+    return value.bit_length() - 1


### PR DESCRIPTION
Fixing issue with extraction logic for Warning and Error codes. Hard to fix, since hard to reproduce, but this one should display error/warning codes much better.