### PR TITLE
draft: split inverter with sub devices PoC

### DIFF
--- a/custom_components/lxp_modbus/entity.py
+++ b/custom_components/lxp_modbus/entity.py
@@ -54,23 +54,33 @@ class ModbusBridgeEntity(CoordinatorEntity):
     def device_info(self):
         """Return device information for all entities."""
         
-        # Get the hold registers from the coordinator's data
-        hold_registers = self.coordinator.data.get("hold", {})
+        if "sub_device" in self._desc:
+            sub_device = self._desc.get("sub_device")
+            return {
+                "identifiers": {(DOMAIN, self._entry.entry_id, sub_device)},
+                "via_device": (DOMAIN, self._entry.entry_id),
+                "name": (self._entry.title or INTEGRATION_TITLE) + " " + sub_device,
+                "manufacturer": "LuxpowerTek",
+                "model": self._entry.data.get("model") or "Unknown",
+            }
+        else:
+            # Get the hold registers from the coordinator's data
+            hold_registers = self.coordinator.data.get("hold", {})
         
-        # Specifically check for the registers required for the firmware version
-        required_fw_regs = {k: hold_registers.get(k) for k in [7, 8, 9, 10]}
+            # Specifically check for the registers required for the firmware version
+            required_fw_regs = {k: hold_registers.get(k) for k in [7, 8, 9, 10]}
 
-        # Use the helper function to format the firmware version
-        firmware_version = format_firmware_version(hold_registers)
+            # Use the helper function to format the firmware version
+            firmware_version = format_firmware_version(hold_registers)
 
-        return {
-            "identifiers": {(DOMAIN, self._entry.entry_id)},
-            "name": self._entry.title or INTEGRATION_TITLE,
-            "manufacturer": "LuxpowerTek",
-            "model": self._entry.data.get("model") or "Unknown",
-            "serial_number": self._entry.data.get(CONF_INVERTER_SERIAL),
-            "sw_version": firmware_version,
-        }
+            return {
+                "identifiers": {(DOMAIN, self._entry.entry_id)},
+                "name": self._entry.title or INTEGRATION_TITLE,
+                "manufacturer": "LuxpowerTek",
+                "model": self._entry.data.get("model") or "Unknown",
+                "serial_number": self._entry.data.get(CONF_INVERTER_SERIAL),
+                "sw_version": firmware_version,
+            }
 
     @property
     def is_master(self) -> bool:

--- a/custom_components/lxp_modbus/entity_descriptions/number_types.py
+++ b/custom_components/lxp_modbus/entity_descriptions/number_types.py
@@ -7,6 +7,7 @@ from ..constants.hold_registers import *
 NUMBER_TYPES = [
     # --- System & Grid ---
     {
+        "sub_device": "Internals",       
         "name": "Modbus Address",
         "register": H_COM_ADDRESS,
         "register_type": "hold",
@@ -21,6 +22,7 @@ NUMBER_TYPES = [
         "master_only": True,
     },
     {
+        "sub_device": "Grid",
         "name": "Grid Connect Time",
         "register": H_CONNECT_TIME,
         "register_type": "hold",

--- a/custom_components/lxp_modbus/entity_descriptions/sensor_types.py
+++ b/custom_components/lxp_modbus/entity_descriptions/sensor_types.py
@@ -92,6 +92,7 @@ SENSOR_TYPES = [
 
     # --- Core Status & PV Information ---
     {
+        "sub_device": "PV",
         "name": "PV1 Voltage",
         "register": I_VPV1,
         "register_type": "input",
@@ -262,6 +263,7 @@ SENSOR_TYPES = [
 
     # --- Battery Information ---
     {
+        "sub_device": "Battery",
         "name": "Battery Voltage",
         "register": I_VBAT,
         "register_type": "input",
@@ -348,6 +350,7 @@ SENSOR_TYPES = [
 
     # --- Grid Information ---
     {
+        "sub_device": "Grid",
         "name": "Grid Voltage",
         "register": I_VAC_R,
         "register_type": "input",
@@ -574,6 +577,7 @@ SENSOR_TYPES = [
 
     # --- EPS (Off-Grid) Information ---
     {
+        "sub_device": "EPS",
         "name": "EPS Voltage",
         "register": I_VEPS_R,
         "register_type": "input",
@@ -842,6 +846,7 @@ SENSOR_TYPES = [
         "master_only": False,
     },
     {
+        "sub_device": "Generator",
         "name": "Generator Energy Today",
         "register": I_EGEN_DAY,
         "register_type": "input",
@@ -900,6 +905,7 @@ SENSOR_TYPES = [
         "master_only": False,
     },
     {
+        "sub_device": "Internals",       
         "name": "Radiator Temperature",
         "register": I_TRADIATOR1,
         "register_type": "input",


### PR DESCRIPTION
Proof of concept about spliting the inverter in sub devices. 

When integration is loaded with this changes it split the main device in sub-devices.

I have just made the definition on some entities for testing and check if @ant0nkr  agree going this way. 

Maybe we can offer to user an option to split or not is some user wants all entities together, but this will help to easily disable modules that are not used like PV, Generator, Grid (for off-grid usage)....

https://github.com/ant0nkr/luxpower-ha-integration/discussions/28#discussioncomment-14540592


![Screenshot_2025-09-30_12-35-08](https://github.com/user-attachments/assets/b8aec410-24e6-4709-a25b-75f5b03253ee)
![Screenshot_2025-09-30_12-34-49](https://github.com/user-attachments/assets/0597183b-004b-4d9f-8058-fa2264787282)
![Screenshot_2025-09-30_12-34-31](https://github.com/user-attachments/assets/84712921-0482-4f3c-b27d-2f7a015b03fa)


