### PR TITLE
forced charge, luxpower web interface enable this after quick charge button pressed

### DIFF
--- a/custom_components/lxp_modbus/entity_descriptions/switch_types.py
+++ b/custom_components/lxp_modbus/entity_descriptions/switch_types.py
@@ -68,6 +68,19 @@ SWITCH_TYPES = [
         "master_only": True,
         "device_group": "Settings & Schedules",
     },
+    {
+        "name": "Forced charge",
+        "register": H_FUNCTION_ENABLE_1, # 21
+        "register_type": "hold",
+        "extract": lambda reg: get_bits(reg, 11, 1),
+        "compose": lambda orig, value: set_bits(orig, 11, 1, value),
+        "icon": "mdi:battery-arrow-up",
+        "device_class": "switch",
+        "enabled": True,
+        "visible": True,
+        "master_only": True,
+        "device_group": "Settings & Schedules",
+    },
     # Register 22: H_FUNCTION_ENABLE_2_AND_PV_START_VOLT
     {
         "name": "Feed-In Grid",


### PR DESCRIPTION
Currently the Quick charge Start switch works fine on my inverter, but I found that when I use the button from luxpower website it does not indicate on the Quick Charge Start switch.

After capturing some packets I found that luxpower website use this function from hold register 21