### PR TITLE
cell difference to help battery callibration to be made / checked from HA

### DIFF
--- a/custom_components/lxp_modbus/entity_descriptions/sensor_types.py
+++ b/custom_components/lxp_modbus/entity_descriptions/sensor_types.py
@@ -1587,6 +1587,22 @@ SENSOR_TYPES = [
         "device_group": "Battery",
     },
     {
+        "name": "BMS Cell Difference",
+        "register_type": "calculated",
+        "depends_on": [I_BMS_MIN_CELL_VOLT, I_BMS_MAX_CELL_VOLT],
+        "extract": lambda registers, entry: (
+            round((registers.get(I_BMS_MAX_CELL_VOLT) - registers.get(I_BMS_MIN_CELL_VOLT)) / 1000.0, 3)
+        ),
+        "unit": "V",
+        "device_class": "voltage",
+        "state_class": "measurement",
+        "icon": "mdi:car-battery",
+        "enabled": False,
+        "visible": True,
+        "master_only": True,
+        "device_group": "Battery",
+    },
+    {
         "name": "BMS Max Cell Temperature",
         "register": I_BMS_MAX_CELL_TEMP,
         "register_type": "input",


### PR DESCRIPTION
for users that have solar connected battery calibration normally is done automatically because battery normally will be fully charged.

In my case that panels are not connected to inverter I have to start charging manually, luxpower support recommended to do full charge every month and consider as calibrated after battery fully charged (100% and no charging current) and cell difference is lower than 10mV (preferable 5mV).

This adds cell difference using MAX and MIN cell Voltages, normally disabled to be enabled only when user need  

