### PR TITLE
flip battery flow sign

### DIFF
--- a/custom_components/lxp_modbus/entity_descriptions/sensor_types.py
+++ b/custom_components/lxp_modbus/entity_descriptions/sensor_types.py
@@ -62,7 +62,7 @@ SENSOR_TYPES = [
         "enabled": True,
         "visible": True,
         "extract": lambda registers, entry: (
-            registers.get(I_PCHARGE, 0) - registers.get(I_PDISCHARGE, 0)
+            registers.get(I_PDISCHARGE, 0) - registers.get(I_PCHARGE, 0)
         ),
         "master_only": False,
         "device_group": "Battery",


### PR DESCRIPTION
Fixes #97 

Flips the flow sensor so it can be easily added to HA's energy dashboard