### PR TITLE
add BMS allowed charge and discharge binary sensors

### DIFF
--- a/custom_components/lxp_modbus/__init__.py
+++ b/custom_components/lxp_modbus/__init__.py
@@ -163,8 +163,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if is_read_only:
         # In read-only mode, we only load the sensor platform.
         # It will be responsible for creating all entities.
-        _LOGGER.info("Read-only mode enabled. Loading sensor platform only.")
-        platforms_to_load = [Platform.SENSOR]
+        _LOGGER.info("Read-only mode enabled. Loading sensor and binary_sensor platforms only.")
+        platforms_to_load = [Platform.SENSOR, Platform.BINARY_SENSOR]
     else:
         # In normal mode, load all platforms.
         platforms_to_load = PLATFORMS

--- a/custom_components/lxp_modbus/binary_sensor.py
+++ b/custom_components/lxp_modbus/binary_sensor.py
@@ -1,0 +1,49 @@
+import logging
+
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import *
+from .entity import ModbusBridgeEntity
+from .entity_descriptions.binary_sensor_types import BINARY_SENSOR_TYPES
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up binary_sensor entities from a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    entity_prefix = hass.data[DOMAIN][entry.entry_id]['settings'].get(CONF_ENTITY_PREFIX, DEFAULT_ENTITY_PREFIX)
+    api_client = hass.data[DOMAIN][entry.entry_id]["api_client"]
+    
+    entities = [
+        ModbusBridgeBinarySensor(coordinator, entry, desc, entity_prefix, api_client)
+        for desc in BINARY_SENSOR_TYPES
+    ]
+    async_add_entities(entities)
+
+class ModbusBridgeBinarySensor(ModbusBridgeEntity, BinarySensorEntity):
+    """Represents a binary_sensor entity that writes a value to a register."""
+
+    def __init__(self, coordinator: DataUpdateCoordinator, entry, desc: dict, entity_prefix: str, api_client):
+        """Initialize the binary_sensor entity."""
+        super().__init__(coordinator, entry, desc, entity_prefix, api_client)
+        
+        self._attr_state_class = self._desc.get("state_class")
+        self._attr_device_class = self._desc.get("device_class")
+        self._attr_icon = desc.get("icon")
+
+    @property
+    def is_on(self):
+        """Return the state of the sensor."""
+        # Don't return a value until the coordinator has fetched data for the first time
+        if not self.coordinator.data:
+            return None
+
+        raw_val = None
+        registers = self.coordinator.data.get(self._register_type, {})
+        value = registers.get(self._register)
+        if value is not None:
+            # Use the 'extract' lambda to parse the value (e.g., for packed bits)
+            raw_val = self._desc["extract"](value)
+
+        return raw_val

--- a/custom_components/lxp_modbus/const.py
+++ b/custom_components/lxp_modbus/const.py
@@ -5,6 +5,7 @@ DOMAIN = "lxp_modbus"
 
 PLATFORMS: Final = [
     Platform.SENSOR,
+    Platform.BINARY_SENSOR,
     Platform.NUMBER,
     Platform.TIME,
     Platform.SELECT,

--- a/custom_components/lxp_modbus/entity_descriptions/binary_sensor_types.py
+++ b/custom_components/lxp_modbus/entity_descriptions/binary_sensor_types.py
@@ -1,0 +1,28 @@
+from ..constants.input_registers import *
+from ..utils import get_bits
+
+BINARY_SENSOR_TYPES = [
+    {
+        "name": "BMS Charge Allowed",
+        "register": I_BMS_BAT_STATUS_INV,
+        "register_type": "input",
+        "extract": lambda value: get_bits(value, 0, 1) != 0,
+        "icon": "mdi:battery",
+        "enabled": True,
+        "visible": True,
+        "device_group": "Battery",
+        "master_only": True,
+    },
+    {
+        "name": "BMS Discharge Allowed",
+        "register": I_BMS_BAT_STATUS_INV,
+        "register_type": "input",
+        "extract": lambda value: get_bits(value, 1, 1) != 0,
+        "icon": "mdi:battery",
+        "enabled": True,
+        "visible": True,
+        "device_group": "Battery",
+        "master_only": True,
+    },
+
+]


### PR DESCRIPTION
This PR add support for binary_sensors

added the **BMS Charge Allowed** and **BMS Discharge Allowed** like on the luxpower website

