### PR TITLE
feat: add Grid Connected binary sensor derived from Inverter State

### DIFF
--- a/custom_components/lxp_modbus/entity_descriptions/binary_sensor_types.py
+++ b/custom_components/lxp_modbus/entity_descriptions/binary_sensor_types.py
@@ -3,6 +3,17 @@ from ..utils import get_bits
 
 BINARY_SENSOR_TYPES = [
     {
+        "name": "Grid Connected",
+        "register": I_STATE,
+        "register_type": "input",
+        "extract": lambda value: value < 64,
+        "device_class": "connectivity",
+        "enabled": True,
+        "visible": True,
+        "device_group": "Grid",
+        "master_only": False,
+    },
+    {
         "name": "BMS Charge Allowed",
         "register": I_BMS_BAT_STATUS_INV,
         "register_type": "input",


### PR DESCRIPTION
Adds a `Grid Connected` binary sensor to `binary_sensor_types.py`.
- `on` → `I_STATE < 64` (all on-grid operational states)
- `off` → `I_STATE >= 64` (all Off-Grid states, per firmware convention)
No new register polling required — `I_STATE` is already fetched every cycle.
Tested on LXP 12k. Feedback welcome from other models to confirm the `< 64` threshold is universal.
Closes #120