### PR TITLE
fix: derive Grid Connected binary sensor using grid input frequency

### DIFF
--- a/custom_components/lxp_modbus/binary_sensor.py
+++ b/custom_components/lxp_modbus/binary_sensor.py
@@ -40,10 +40,15 @@ class ModbusBridgeBinarySensor(ModbusBridgeEntity, BinarySensorEntity):
             return None
 
         raw_val = None
-        registers = self.coordinator.data.get(self._register_type, {})
-        value = registers.get(self._register)
-        if value is not None:
-            # Use the 'extract' lambda to parse the value (e.g., for packed bits)
-            raw_val = self._desc["extract"](value)
+
+        if self._register_type == "calculated":
+            input_data = self.coordinator.data.get("input", {})
+            raw_val = self._desc["extract"](input_data, self._entry)
+        else:
+            registers = self.coordinator.data.get(self._register_type, {})
+            value = registers.get(self._register)
+            if value is not None:
+                # Use the 'extract' lambda to parse the value (e.g., for packed bits)
+                raw_val = self._desc["extract"](value)
 
         return raw_val

--- a/custom_components/lxp_modbus/entity_descriptions/binary_sensor_types.py
+++ b/custom_components/lxp_modbus/entity_descriptions/binary_sensor_types.py
@@ -3,10 +3,14 @@ from ..utils import get_bits
 
 BINARY_SENSOR_TYPES = [
     {
+        # True when the utility grid is physically present, regardless of whether
+        # the inverter is currently grid-tied or intentionally islanding.
+        # I_FAC (register 15) is the grid-input frequency in 0.01 Hz units.
+        # It reads 0 when no grid AC is present and ~5000-6000 when the grid is live.
         "name": "Grid Connected",
-        "register": I_STATE,
-        "register_type": "input",
-        "extract": lambda value: value < 64,
+        "register_type": "calculated",
+        "depends_on": [I_FAC],
+        "extract": lambda registers, entry: registers.get(I_FAC, 0) > 0,
         "device_class": "connectivity",
         "enabled": True,
         "visible": True,


### PR DESCRIPTION
Modify the new Grid Connected binary sensor to the Grid device group. It now derives its state from I_FAC (register 15, grid input frequency), which reads 0 when no utility AC is present and ~5000–6000 when live.

Using grid frequency works universally across all inverter models without relying on model-specific registers, and correctly reflectsphysical grid presence regardless of the inverter's operating mode (e.g. intentional off-grid / Power Backup).

Also extends binary sensor to support the calculated register type, consistent with how multi-register sensors are already handled.