### PR TITLE
fix battery registers reading on v 1.0.0

### DIFF
--- a/custom_components/lxp_modbus/classes/modbus_client.py
+++ b/custom_components/lxp_modbus/classes/modbus_client.py
@@ -74,7 +74,7 @@ class LxpModbusApiClient:
 
     async def async_request_registers(self, writer, reader, reg, request_type, function_code) -> dict:
         """Request a block of registers and return parsed values."""
-        count = min(self._block_size, TOTAL_REGISTERS - reg)
+        count = min(self._block_size, TOTAL_REGISTERS - reg) if (reg < BATTERY_INFO_START_REGISTER) else self._block_size
         req = LxpRequestBuilder.prepare_packet_for_read(
             self._dongle_serial.encode(), self._inverter_serial.encode(),
             reg, count, function_code
@@ -117,7 +117,8 @@ class LxpModbusApiClient:
                                   request_type, function_code, len(response.parsed_values_dictionary), count)
 
                 # Battery data needs special decoding — returns dict keyed by serial
-                if response.register == BATTERY_INFO_START_REGISTER:
+                # This will not work correctly with small blocks if they are not aligned
+                if response.register >= BATTERY_INFO_START_REGISTER:
                     bat_dict = LxpBatteries(response).get_battery_info()
                     _LOGGER.debug("Battery data decoded: %s", list(bat_dict.keys()))
                     return bat_dict


### PR DESCRIPTION
after upgrading to v1.0.0 I got the error 


> Total polling failure: can't convert negative int to unsigned. Consecutive failures: 1. Last success: 0h 0m 6s ago


like the user reported on #115 in my case  is because the read routine is capping on TOTAL_REGISTERS and BATTERY registers are over this range resulting in negative number of registers to read.

I got error on line 35, dont know if the #115 case is exactly the same

https://github.com/ivanfmartinez/luxpower-ha-integration/blob/e8601c2f5db21e7f9a9ead05e45e740fbc96c752/custom_components/lxp_modbus/classes/lxp_request_builder.py#L35



