### PR TITLE
fix: correct Reboot Inverter button lambda signature

### DIFF
--- a/custom_components/lxp_modbus/entity_descriptions/button_types.py
+++ b/custom_components/lxp_modbus/entity_descriptions/button_types.py
@@ -7,7 +7,7 @@ BUTTON_TYPES = [
         "name": "Reboot Inverter",
         "register": H_RESET_SETTINGS, # 11
         "register_type": "hold",
-        "press": lambda orig, value: set_bits(orig, 7, 1, value),
+        "press": lambda orig: set_bits(orig, 7, 1, 1),
         "icon": "mdi:restart-alert",
         "enabled": True,
         "visible": True,


### PR DESCRIPTION
The press lambda accepted two arguments (orig, value) but the button handler only passes one (orig), causing a TypeError when the button was pressed. The value to write is always 1 (set bit 7), so the unused argument is removed.

Please test it too if possible, I have the feeling the integration is not reconnecting well to the inverter after it reboots... 