### PR TITLE
fix: preserve unsigned 16-bit values when writing hold registers

### DIFF
--- a/custom_components/lxp_modbus/classes/lxp_request_builder.py
+++ b/custom_components/lxp_modbus/classes/lxp_request_builder.py
@@ -61,7 +61,9 @@ class LxpRequestBuilder:
         buf += LxpRequestBuilder.WRITE_SINGLE.to_bytes(1, 'little')
         buf += serial_number
         buf += register.to_bytes(2, 'little')
-        buf += value.to_bytes(2, 'little', signed=True)
+        # Modbus holding register writes are 16-bit values; preserve the full
+        # register word even when high bits are set on bitfield-style registers.
+        buf += (value & 0xFFFF).to_bytes(2, 'little')
 
         data_frame = bytes(buf[20:36])  # always 16 bytes
         crc = LxpPacketUtils.compute_crc(data_frame)

--- a/tests/test_lxp_request_builder.py
+++ b/tests/test_lxp_request_builder.py
@@ -1,0 +1,32 @@
+"""Tests for LxpRequestBuilder."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from custom_components.lxp_modbus.classes.lxp_request_builder import LxpRequestBuilder
+
+
+def test_prepare_packet_for_write_accepts_register_values_above_signed_range():
+    """Register writes should preserve the full 16-bit word."""
+    packet = LxpRequestBuilder.prepare_packet_for_write(
+        b"DG44302247",
+        b"4434280298",
+        21,
+        62404,
+    )
+
+    assert packet[-4:-2] == bytes([0xC4, 0xF3])
+
+
+def test_prepare_packet_for_write_masks_values_to_unsigned_16_bit():
+    """Values should be encoded as unsigned 16-bit register contents."""
+    packet = LxpRequestBuilder.prepare_packet_for_write(
+        b"DG44302247",
+        b"4434280298",
+        21,
+        0x1FFFF,
+    )
+
+    assert packet[-4:-2] == bytes([0xFF, 0xFF])


### PR DESCRIPTION
Thanks to @akurze11 for identifying the root cause in #131 and outlining the fix.

I am observing that controls tied to register 21, including AC Charging and Power Backup, appear to toggle in Home Assistant, but the inverter does not actually change state. The logs show "int too big to convert," followed by 'Failed to write register 21 after 3 attempts," so the write never succeeds.

This issue prevents me from using AC charging on my EG4 18kPV to precharge the battery on cloudy days to avoid peak-hour grid usage, and it also prevents me from charging the battery ahead of planned utility outages while the utility is doing upgrade work in my area. Because the switch does not work.

This PR updates hold-register writes to preserve the full 16-bit register value instead of encoding it as a signed 16-bit integer. That allows bitfield-style registers such as 21 and 22 to be written correctly even when high bits are already set.

Fixes #131.