### PR TITLE
perf: stop re-reading settings and empty battery blocks every poll

### DIFF
--- a/custom_components/lxp_modbus/__init__.py
+++ b/custom_components/lxp_modbus/__init__.py
@@ -43,6 +43,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Determine if battery data should be requested
     battery_entities = entry.data.get(CONF_BATTERY_ENTITIES, DEFAULT_BATTERY_ENTITIES).replace(" ", "").split(",")
     request_battery_data = bool(battery_entities) and 'none' not in battery_entities
+    # Explicit serials mean the user asserts those packs exist, so the battery block
+    # keeps being polled every cycle even if it stays empty.
+    battery_serials_configured = any(
+        value not in ('', 'none', 'auto') for value in battery_entities
+    )
 
     # Create a single asyncio.Lock to prevent read/write race conditions
     lock = asyncio.Lock()
@@ -50,7 +55,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     connection_retries = entry.data.get(CONF_CONNECTION_RETRIES, DEFAULT_CONNECTION_RETRIES)
     api_client = LxpModbusApiClient(
         host, port, dongle_serial, inverter_serial, lock, block_size, connection_retries,
-        request_battery_data=request_battery_data
+        request_battery_data=request_battery_data,
+        battery_serials_configured=battery_serials_configured,
     )
 
     # Create our custom coordinator

--- a/custom_components/lxp_modbus/classes/modbus_client.py
+++ b/custom_components/lxp_modbus/classes/modbus_client.py
@@ -6,8 +6,11 @@ import time as time_lib
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from ..const import (
+    BATTERY_BACKOFF_POLL_EVERY,
+    BATTERY_EMPTY_POLLS_BEFORE_BACKOFF,
     BATTERY_INFO_START_REGISTER,
     DEFAULT_CONNECTION_RETRIES,
+    HOLD_REGISTER_POLL_EVERY,
     INITIAL_RETRY_DELAY,
     MAX_CACHED_DATA_FAILURES,
     MAX_RETRY_DELAY,
@@ -44,7 +47,8 @@ class LxpModbusApiClient:
 
     def __init__(self, host: str, port: int, dongle_serial: str, inverter_serial: str, lock: asyncio.Lock,
                  block_size: int = 125, connection_retries: int = DEFAULT_CONNECTION_RETRIES,
-                 skip_initial_data: bool = True, request_battery_data: bool = False):
+                 skip_initial_data: bool = True, request_battery_data: bool = False,
+                 battery_serials_configured: bool = False):
         """Initialize the API client."""
         self._dongle_serial = dongle_serial
         self._inverter_serial = inverter_serial
@@ -52,12 +56,22 @@ class LxpModbusApiClient:
         self._block_size = block_size
         self._connection_retries = connection_retries
         self._request_battery_data = request_battery_data
+        # Explicitly listed serials are an assertion that packs exist, so their
+        # block is never polled less often — silence there is a fault to surface.
+        self._battery_serials_configured = battery_serials_configured
         self._last_good_input_regs = {}
         self._last_good_hold_regs = {}
         self._last_good_battery_data = {}
         self._connection_retry_count = 0
         self._last_successful_connection = None
         self._connection_failure_count = 0
+        self._poll_count = 0
+        self._hold_polls = 0
+        self._polls_since_hold = 0
+        self._battery_empty_polls = 0
+        self._battery_skipped_polls = 0
+        self._battery_backoff_counter = 0
+        self._force_hold_poll = True  # first poll must read settings
 
         # Composed dependencies
         self._connection_manager = ModbusConnectionManager(
@@ -139,6 +153,63 @@ class LxpModbusApiClient:
         """Get packet recovery statistics for monitoring and debugging."""
         return self._packet_recovery.get_stats()
 
+    def request_hold_refresh(self) -> None:
+        """Make the next poll re-read the hold registers.
+
+        Called after a successful write so the change is confirmed against the
+        inverter on the very next poll instead of waiting for the settings cycle.
+        """
+        self._force_hold_poll = True
+
+    def _should_poll_hold(self) -> bool:
+        """Decide whether this poll re-reads the settings registers."""
+        self._poll_count += 1
+
+        if self._force_hold_poll:
+            self._force_hold_poll = False
+            self._polls_since_hold = 0
+            return True
+
+        self._polls_since_hold += 1
+        if self._polls_since_hold >= HOLD_REGISTER_POLL_EVERY:
+            self._polls_since_hold = 0
+            return True
+        return False
+
+    def _should_poll_battery(self) -> bool:
+        """Decide whether this poll reads the battery register block."""
+        # A configured serial list asserts the packs exist, so keep asking.
+        if self._battery_serials_configured:
+            return True
+
+        if self._battery_empty_polls < BATTERY_EMPTY_POLLS_BEFORE_BACKOFF:
+            return True
+
+        self._battery_backoff_counter += 1
+        if self._battery_backoff_counter >= BATTERY_BACKOFF_POLL_EVERY:
+            self._battery_backoff_counter = 0
+            return True
+        return False
+
+    def _record_battery_result(self, got_data: bool) -> None:
+        """Track whether the battery block is producing anything."""
+        if got_data:
+            if self._battery_empty_polls >= BATTERY_EMPTY_POLLS_BEFORE_BACKOFF:
+                _LOGGER.info("Battery data is available again; polling it every cycle.")
+            self._battery_empty_polls = 0
+            self._battery_backoff_counter = 0
+            return
+
+        self._battery_empty_polls += 1
+        if self._battery_empty_polls == BATTERY_EMPTY_POLLS_BEFORE_BACKOFF:
+            _LOGGER.info(
+                "The battery register block has returned no data %s times, so it will be "
+                "polled every %s cycles from now on. Some batteries do not publish this "
+                "data even when the inverter reports packs connected. Polling returns to "
+                "every cycle as soon as any data appears.",
+                self._battery_empty_polls, BATTERY_BACKOFF_POLL_EVERY,
+            )
+
     def _snapshot(self) -> dict:
         """Return a copy of the last known good dataset.
 
@@ -206,6 +277,8 @@ class LxpModbusApiClient:
         newly_polled_battery_data = {}
         writer = None
 
+        poll_hold = self._should_poll_hold()
+
         async with self._lock:
             reader, writer = await self._connection_manager.async_connect()
             try:
@@ -224,18 +297,25 @@ class LxpModbusApiClient:
                             and I_BAT_PARALLEL_NUM in newly_polled_input_regs
                             and newly_polled_input_regs[I_BAT_PARALLEL_NUM] > 0
                             and self._block_size >= 120):
-                        for reg in range(BATTERY_INFO_START_REGISTER,
-                                         BATTERY_INFO_START_REGISTER + 120,
-                                         self._block_size):
-                            bat_block = await self.async_request_registers(
-                                writer, reader, reg, "input/bat", 4)
-                            newly_polled_battery_data.update(bat_block)
+                        if self._should_poll_battery():
+                            for reg in range(BATTERY_INFO_START_REGISTER,
+                                             BATTERY_INFO_START_REGISTER + 120,
+                                             self._block_size):
+                                bat_block = await self.async_request_registers(
+                                    writer, reader, reg, "input/bat", 4)
+                                newly_polled_battery_data.update(bat_block)
+                            self._record_battery_result(bool(newly_polled_battery_data))
+                        else:
+                            self._battery_skipped_polls += 1
 
-                    # Poll HOLD registers (expecting function code 3)
-                    for reg in range(0, TOTAL_REGISTERS, self._block_size):
-                        reg_block = await self.async_request_registers(writer, reader, reg, "hold", 3)
-                        if len(reg_block) > 0:
-                            newly_polled_hold_regs.update(reg_block)
+                    # Poll HOLD registers (expecting function code 3). These are
+                    # settings, so they are not re-read on every poll.
+                    if poll_hold:
+                        for reg in range(0, TOTAL_REGISTERS, self._block_size):
+                            reg_block = await self.async_request_registers(writer, reader, reg, "hold", 3)
+                            if len(reg_block) > 0:
+                                newly_polled_hold_regs.update(reg_block)
+                        self._hold_polls += 1
 
                 except asyncio.TimeoutError:
                     _LOGGER.debug("Timeout requesting data from inverter")
@@ -347,6 +427,9 @@ class LxpModbusApiClient:
                 received_value = response_dict.get(register)
                 if received_value == value:
                     _LOGGER.info("Successfully wrote register %s with value %s.", register, value)
+                    # Settings are not read on every poll, so make sure the next one
+                    # picks up what the inverter actually stored.
+                    self.request_hold_refresh()
                     return True
 
                 _LOGGER.warning("Write attempt %s failed: Confirmation mismatch, sent=%s received=%s",
@@ -365,6 +448,12 @@ class LxpModbusApiClient:
             "block_size": self._block_size,
             "connection_retries": self._connection_retries,
             "request_battery_data": self._request_battery_data,
+            "battery_serials_configured": self._battery_serials_configured,
+            "polls": self._poll_count,
+            "hold_polls": self._hold_polls,
+            "hold_poll_every": HOLD_REGISTER_POLL_EVERY,
+            "battery_empty_polls": self._battery_empty_polls,
+            "battery_skipped_polls": self._battery_skipped_polls,
             "consecutive_failures": self._connection_failure_count,
             "reconnect_count": self._connection_retry_count,
             "last_success": self._last_success_description(),

--- a/custom_components/lxp_modbus/const.py
+++ b/custom_components/lxp_modbus/const.py
@@ -72,5 +72,17 @@ MAX_CACHED_DATA_FAILURES = 2
 # A register the inverter does not implement reads back with all bits set
 UNIMPLEMENTED_REGISTER_VALUE = 0xFFFF
 
+# Hold registers hold configuration: they only change when something writes them,
+# so re-reading them on every poll doubles the request count for no new data. They
+# are refreshed every Nth poll, and always immediately after a successful write.
+HOLD_REGISTER_POLL_EVERY = 5
+
+# Some batteries report nothing on the battery register block even though the
+# inverter reports packs connected (non-LuxPower BMS). Rather than give up, the
+# block is polled less often after repeated empty responses, and every poll again
+# as soon as any data appears.
+BATTERY_EMPTY_POLLS_BEFORE_BACKOFF = 5
+BATTERY_BACKOFF_POLL_EVERY = 10
+
 # Serial number validation
 SERIAL_LENGTH = 10

--- a/custom_components/lxp_modbus/entity.py
+++ b/custom_components/lxp_modbus/entity.py
@@ -1,5 +1,6 @@
 """Base class for LuxPower Modbus entities."""
 import logging
+from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, CoordinatorEntity
 from homeassistant.helpers.entity import generate_entity_id
 from .utils import format_firmware_version
@@ -13,6 +14,9 @@ class ModbusBridgeEntity(CoordinatorEntity):
 
     # Subclasses can set _battery_serial before calling super().__init__()
     _battery_serial = None
+
+    # Sentinel distinct from None, which is a legitimate register value
+    _last_fingerprint = object()
 
     def __init__(self, coordinator: DataUpdateCoordinator, entry, desc: dict, entity_prefix: str, api_client):
 
@@ -94,15 +98,43 @@ class ModbusBridgeEntity(CoordinatorEntity):
         await self.coordinator.async_request_refresh()
         return True
 
-    @property
-    def extra_state_attributes(self):
-        """Return the state attributes."""
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Write state only when this entity's own source data changed.
+
+        Every entity listens to the coordinator, and there are several hundred of
+        them per inverter. Writing state unconditionally on each poll costs a full
+        state machine update per entity even though most registers never move.
+        """
+        fingerprint = self._source_fingerprint()
+        if fingerprint is not None and fingerprint == self._last_fingerprint:
+            return
+        self._last_fingerprint = fingerprint
+        super()._handle_coordinator_update()
+
+    def _source_fingerprint(self):
+        """Return a value that changes only when this entity's inputs change.
+
+        Returns None when no cheap fingerprint is available, which forces a write.
+        """
+        data = self.coordinator.data
+        if not data:
+            return None
+
         if self._register_type.endswith("calculated"):
-            return {"dependencies": self._desc.get("depends_on")}
-        return {
-            "register": self._register,
-            "register_type": self._register_type,
-        }
+            # Calculated entities derive from several registers.
+            source = data.get("battery", {}).get(self._battery_serial, {}) \
+                if self._register_type == "battery_calculated" else data.get("input", {})
+            depends_on = self._desc.get("depends_on")
+            if not depends_on:
+                return None
+            return tuple(source.get(register) for register in depends_on)
+
+        if self._register_type == "battery":
+            source = data.get("battery", {}).get(self._battery_serial, {})
+        else:
+            source = data.get(self._register_type, {})
+        return source.get(self._register)
 
 
     @property

--- a/tests/test_entity_write.py
+++ b/tests/test_entity_write.py
@@ -263,5 +263,88 @@ class TestSharedWritePath:
         assert len(written) == 2
 
 
+class TestUnchangedStateSuppression:
+    """Several hundred entities share one coordinator; unchanged ones stay quiet."""
+
+    def test_no_write_when_the_register_is_unchanged(self, coordinator, entry, api_client):
+        """Most registers never move, so most entities should do nothing."""
+        coordinator.data["hold"][228] = 585
+        entity = make_number(coordinator, entry, api_client)
+        entity._handle_coordinator_update()          # first update establishes the value
+        entity.async_write_ha_state.reset_mock()
+
+        entity._handle_coordinator_update()
+        entity._handle_coordinator_update()
+
+        entity.async_write_ha_state.assert_not_called()
+
+    def test_writes_when_the_register_changes(self, coordinator, entry, api_client):
+        """A real change must still reach Home Assistant."""
+        coordinator.data["hold"][228] = 585
+        entity = make_number(coordinator, entry, api_client)
+        entity._handle_coordinator_update()
+        entity.async_write_ha_state.reset_mock()
+
+        coordinator.data["hold"][228] = 590
+        entity._handle_coordinator_update()
+
+        entity.async_write_ha_state.assert_called_once()
+
+    def test_first_update_always_writes(self, coordinator, entry, api_client):
+        """The initial value has to be published."""
+        coordinator.data["hold"][228] = 585
+        entity = make_number(coordinator, entry, api_client)
+
+        entity._handle_coordinator_update()
+
+        entity.async_write_ha_state.assert_called_once()
+
+    def test_appearing_register_writes(self, coordinator, entry, api_client):
+        """A register that shows up after being absent is a change."""
+        entity = make_number(coordinator, entry, api_client)
+        entity._handle_coordinator_update()          # absent -> None
+        entity.async_write_ha_state.reset_mock()
+
+        coordinator.data["hold"][228] = 585
+        entity._handle_coordinator_update()
+
+        entity.async_write_ha_state.assert_called_once()
+
+    def test_calculated_entity_tracks_all_dependencies(self, coordinator, entry, api_client):
+        """Calculated entities must react to any of their inputs moving."""
+        calc_desc = {
+            "name": "Battery Flow",
+            "register_type": "calculated",
+            "depends_on": [10, 11],
+            "unit": "W",
+            "min": -100000,
+            "max": 100000,
+            "step": 1,
+            "multiplier": 1,
+            "master_only": False,
+        }
+        coordinator.data["input"] = {10: 100, 11: 0}
+        entity = make_number(coordinator, entry, api_client, calc_desc)
+        entity._handle_coordinator_update()
+        entity.async_write_ha_state.reset_mock()
+
+        entity._handle_coordinator_update()
+        entity.async_write_ha_state.assert_not_called()
+
+        coordinator.data["input"][11] = 50
+        entity._handle_coordinator_update()
+        entity.async_write_ha_state.assert_called_once()
+
+    def test_register_metadata_is_not_in_state_attributes(self, coordinator, entry, api_client):
+        """Static metadata on every entity is recorder weight for no benefit."""
+        coordinator.data["hold"][228] = 585
+        entity = make_number(coordinator, entry, api_client)
+
+        attributes = entity.extra_state_attributes or {}
+
+        assert "register" not in attributes
+        assert "register_type" not in attributes
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_poll_cadence.py
+++ b/tests/test_poll_cadence.py
@@ -1,0 +1,170 @@
+"""Tests for hold-register poll cadence and battery block back-off."""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from custom_components.lxp_modbus.classes.modbus_client import LxpModbusApiClient
+from custom_components.lxp_modbus.const import (
+    BATTERY_BACKOFF_POLL_EVERY,
+    BATTERY_EMPTY_POLLS_BEFORE_BACKOFF,
+    HOLD_REGISTER_POLL_EVERY,
+)
+
+
+def make_client(**kwargs):
+    """Build a client with a real lock and no network."""
+    return LxpModbusApiClient(
+        "192.0.2.1", 8000, "BA0000000A", "0000000001", asyncio.Lock(), **kwargs
+    )
+
+
+class TestHoldPollCadence:
+    """Settings registers are configuration and are not re-read every poll."""
+
+    def test_first_poll_reads_hold(self):
+        """Setup must populate settings, or every control starts unknown."""
+        client = make_client()
+
+        assert client._should_poll_hold() is True
+
+    def test_hold_is_skipped_until_the_interval_elapses(self):
+        """Only every Nth poll pays for the settings blocks."""
+        client = make_client()
+        client._should_poll_hold()  # consume the forced first poll
+
+        decisions = [client._should_poll_hold() for _ in range(HOLD_REGISTER_POLL_EVERY)]
+
+        assert decisions[:-1] == [False] * (HOLD_REGISTER_POLL_EVERY - 1)
+        assert decisions[-1] is True
+
+    def test_cadence_repeats(self):
+        """Over many polls the ratio holds."""
+        client = make_client()
+        polls = 100
+        reads = sum(1 for _ in range(polls) if client._should_poll_hold())
+
+        # First poll is forced, the rest follow the interval.
+        expected = 1 + (polls - 1) // HOLD_REGISTER_POLL_EVERY
+        assert reads == pytest.approx(expected, abs=1)
+
+    def test_request_hold_refresh_forces_the_next_poll(self):
+        """A write must be confirmed on the next poll, not up to N polls later."""
+        client = make_client()
+        client._should_poll_hold()
+        assert client._should_poll_hold() is False
+
+        client.request_hold_refresh()
+
+        assert client._should_poll_hold() is True
+
+    def test_forced_refresh_resets_the_interval(self):
+        """After a forced read the interval starts again, it does not double up."""
+        client = make_client()
+        client._should_poll_hold()
+        client.request_hold_refresh()
+        client._should_poll_hold()
+
+        decisions = [client._should_poll_hold() for _ in range(HOLD_REGISTER_POLL_EVERY - 1)]
+        assert decisions == [False] * (HOLD_REGISTER_POLL_EVERY - 1)
+
+    @pytest.mark.asyncio
+    async def test_successful_write_requests_a_hold_refresh(self, ):
+        """The client itself flags the refresh, so every platform benefits."""
+        client = make_client(connection_retries=1)
+        reader, writer = AsyncMock(spec=asyncio.StreamReader), AsyncMock(spec=asyncio.StreamWriter)
+        writer.write = MagicMock()
+        reader.read = AsyncMock(return_value=b"\x00" * 76)
+        client._should_poll_hold()          # consume the forced first poll
+        client._should_poll_hold()          # now inside the interval
+        client._force_hold_poll = False
+
+        with patch('asyncio.open_connection', return_value=(reader, writer)):
+            with patch('custom_components.lxp_modbus.classes.modbus_client.LxpResponse') as response:
+                response.return_value = MagicMock(
+                    packet_error=False, parsed_values_dictionary={100: 500}
+                )
+                assert await client.async_write_register(100, 500) is True
+
+        assert client._force_hold_poll is True
+
+
+class TestBatteryBackoff:
+    """Some batteries never publish the 5000+ block even with packs connected."""
+
+    def test_polled_every_cycle_initially(self):
+        """Nothing is assumed until the block has actually been tried."""
+        client = make_client()
+
+        assert all(client._should_poll_battery() for _ in range(BATTERY_EMPTY_POLLS_BEFORE_BACKOFF))
+
+    def test_backs_off_after_repeated_empty_responses(self):
+        """After enough empty reads the block stops being polled every cycle."""
+        client = make_client()
+        for _ in range(BATTERY_EMPTY_POLLS_BEFORE_BACKOFF):
+            client._record_battery_result(False)
+
+        decisions = [client._should_poll_battery() for _ in range(BATTERY_BACKOFF_POLL_EVERY)]
+
+        assert decisions[:-1] == [False] * (BATTERY_BACKOFF_POLL_EVERY - 1)
+        assert decisions[-1] is True, "back-off must retry, never give up permanently"
+
+    def test_never_gives_up_permanently(self):
+        """A pack that starts answering later must still be found."""
+        client = make_client()
+        for _ in range(BATTERY_EMPTY_POLLS_BEFORE_BACKOFF):
+            client._record_battery_result(False)
+
+        polls = BATTERY_BACKOFF_POLL_EVERY * 5
+        retries = sum(1 for _ in range(polls) if client._should_poll_battery())
+
+        assert retries >= 4
+
+    def test_any_data_restores_every_cycle_polling(self):
+        """LuxPower-brand packs that answer must not be penalised."""
+        client = make_client()
+        for _ in range(BATTERY_EMPTY_POLLS_BEFORE_BACKOFF):
+            client._record_battery_result(False)
+        assert client._should_poll_battery() is False
+
+        client._record_battery_result(True)
+
+        assert all(client._should_poll_battery() for _ in range(BATTERY_EMPTY_POLLS_BEFORE_BACKOFF))
+
+    def test_packs_that_answer_immediately_never_back_off(self):
+        """The common case must be completely unaffected."""
+        client = make_client()
+        for _ in range(50):
+            assert client._should_poll_battery() is True
+            client._record_battery_result(True)
+
+    def test_explicit_serials_never_back_off(self):
+        """Configured serials assert the packs exist, so silence is a fault."""
+        client = make_client(battery_serials_configured=True)
+        for _ in range(BATTERY_EMPTY_POLLS_BEFORE_BACKOFF * 3):
+            client._record_battery_result(False)
+
+        assert all(client._should_poll_battery() for _ in range(20))
+
+
+class TestCadenceDiagnostics:
+    """The counters exist so a support dump can show what was skipped."""
+
+    def test_connection_stats_report_cadence(self):
+        client = make_client()
+        client._should_poll_hold()
+
+        stats = client.get_connection_stats()
+
+        assert stats["hold_poll_every"] == HOLD_REGISTER_POLL_EVERY
+        assert stats["polls"] == 1
+        assert "battery_empty_polls" in stats
+        assert "battery_skipped_polls" in stats
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
A poll was issuing 13 requests and taking 10.6s against a ~20s interval, over half of it spent re-reading data that had not changed.

Hold registers are configuration: they only change when something writes them. They are now read on the first poll, every fifth poll after that, and always immediately after a successful write, so a change is still confirmed on the very next poll. The client sets that flag itself, so every platform benefits without each one having to remember.

The battery register block is polled every cycle until it has come back empty five times, then every tenth cycle, and every cycle again as soon as any data appears. Some batteries never publish this block even though the inverter reports packs connected: one test system reports three packs at 320Ah with registers 5000-5119 reading all zeros. Back-off is never permanent, so a pack whose BMS starts answering later is still discovered, and packs that answer immediately are never affected. A configured serial list is treated as an assertion that the packs exist and is never backed off.

Measured against that system's timings: 390 requests per 30 polls drops to 223, a 43% reduction, and the duty cycle falls from roughly 48% to 28%.

Entities now write state only when their own registers change. Every entity listens to the coordinator and there are several hundred per inverter, so an unconditional write per poll cost a state machine update each for registers that mostly never move. Calculated entities compare all of their dependencies.

Register metadata is no longer attached to every state. It was static, and it was being written into every recorder row.

Diagnostics report the poll counters so a support dump shows what was skipped.