### PR TITLE
fix: confirm writes on the write connection instead of a full poll (#154)

### DIFF
--- a/custom_components/lxp_modbus/classes/modbus_client.py
+++ b/custom_components/lxp_modbus/classes/modbus_client.py
@@ -416,56 +416,95 @@ class LxpModbusApiClient:
                 _LOGGER.warning("Write attempt %s for register %s timed out waiting for acknowledgement",
                                 attempt + 1, register)
                 return False
+            else:
+                result = self._evaluate_write_response(response_buf, register, value, attempt)
+                if result is True:
+                    # Reuse the open connection: confirming here costs one request,
+                    # where a full poll costs one per register block.
+                    await self._async_reread_hold_block(writer, reader, register)
+                return result
             finally:
                 await self._connection_manager.async_close(writer)
 
-            _LOGGER.debug(
-                "Modbus WRITE: Sent to reg %s, value %s, resp: %s",
-                register, value, response_buf.hex() if response_buf else "None"
-            )
+    def _evaluate_write_response(self, response_buf: bytes, register: int, value: int,
+                                 attempt: int) -> bool | None:
+        """Judge a write acknowledgement packet."""
+        _LOGGER.debug(
+            "Modbus WRITE: Sent to reg %s, value %s, resp: %s",
+            register, value, response_buf.hex() if response_buf else "None"
+        )
 
-            # --- Response Validation ---
-            if not response_buf:
-                _LOGGER.warning("Write attempt %d failed: Response not received", attempt + 1)
-                return False
-
-            response = LxpResponse(response_buf)
-
-            # A function code with the high bit set is a Modbus exception: the
-            # inverter received the write and refused it. Report why rather than
-            # calling it a confirmation mismatch, which reads like our own bug.
-            if response.device_function >= 0x80 or response.exception:
-                reason = MODBUS_EXCEPTION_MESSAGES.get(
-                    response.exception, f"unknown exception code {response.exception}"
-                )
-                _LOGGER.error(
-                    "The inverter rejected the write of value %s to register %s: %s. %s",
-                    value, register, reason, response.info,
-                )
-                return None
-
-            if response.packet_error:
-                _LOGGER.warning("Write attempt %s failed: Inverter returned a packet error. %s",
-                                attempt + 1, response.info)
-                return False
-
-            response_dict = response.parsed_values_dictionary
-            if register in response_dict:
-                received_value = response_dict.get(register)
-                if received_value == value:
-                    _LOGGER.info("Successfully wrote register %s with value %s.", register, value)
-                    # Settings are not read on every poll, so make sure the next one
-                    # picks up what the inverter actually stored.
-                    self.request_hold_refresh()
-                    return True
-
-                _LOGGER.warning("Write attempt %s failed: Confirmation mismatch, sent=%s received=%s",
-                                attempt + 1, value, received_value)
-            else:
-                _LOGGER.warning("Write attempt %s failed: Confirmation mismatch, written register %s not received on confirmation. %s",
-                                attempt + 1, register, response.info)
-
+        if not response_buf:
+            _LOGGER.warning("Write attempt %d failed: Response not received", attempt + 1)
             return False
+
+        response = LxpResponse(response_buf)
+
+        # A function code with the high bit set is a Modbus exception: the
+        # inverter received the write and refused it. Report why rather than
+        # calling it a confirmation mismatch, which reads like our own bug.
+        if response.device_function >= 0x80 or response.exception:
+            reason = MODBUS_EXCEPTION_MESSAGES.get(
+                response.exception, f"unknown exception code {response.exception}"
+            )
+            _LOGGER.error(
+                "The inverter rejected the write of value %s to register %s: %s. %s",
+                value, register, reason, response.info,
+            )
+            return None
+
+        if response.packet_error:
+            _LOGGER.warning("Write attempt %s failed: Inverter returned a packet error. %s",
+                            attempt + 1, response.info)
+            return False
+
+        response_dict = response.parsed_values_dictionary
+        if register in response_dict:
+            received_value = response_dict.get(register)
+            if received_value == value:
+                _LOGGER.info("Successfully wrote register %s with value %s.", register, value)
+                # The acknowledgement echoes what the inverter stored, so the cache
+                # can hold a confirmed value without waiting for any read.
+                self._last_good_hold_regs[register] = received_value
+                return True
+
+            _LOGGER.warning("Write attempt %s failed: Confirmation mismatch, sent=%s received=%s",
+                            attempt + 1, value, received_value)
+        else:
+            _LOGGER.warning("Write attempt %s failed: Confirmation mismatch, written register %s not received on confirmation. %s",
+                            attempt + 1, register, response.info)
+
+        return False
+
+    async def _async_reread_hold_block(self, writer, reader, register: int) -> None:
+        """Re-read the settings block holding ``register`` on the write connection.
+
+        A write can move sibling registers the inverter derives from it, so the
+        block is re-read rather than trusting the acknowledgement alone. Only the
+        one block is read: a full settings pass costs a request per block and is
+        what made a write take tens of seconds to show up.
+        """
+        block_start = (register // self._block_size) * self._block_size
+
+        try:
+            reg_block = await self.async_request_registers(writer, reader, block_start, "hold", 3)
+        except (asyncio.TimeoutError, ConnectionResetError, OSError) as err:
+            _LOGGER.debug("Post-write re-read of hold %s failed (%s); "
+                          "deferring to the next poll.", block_start, err)
+            self.request_hold_refresh()
+            return
+
+        if reg_block:
+            self._last_good_hold_regs.update(reg_block)
+            return
+
+        _LOGGER.debug("Post-write re-read of hold block %s returned nothing; "
+                      "deferring to the next poll.", block_start)
+        self.request_hold_refresh()
+
+    def get_cached_data(self) -> dict:
+        """Return the current known-good dataset without contacting the inverter."""
+        return self._snapshot()
 
     def get_connection_stats(self) -> dict:
         """Return connection statistics for diagnostics."""

--- a/custom_components/lxp_modbus/entity.py
+++ b/custom_components/lxp_modbus/entity.py
@@ -89,13 +89,17 @@ class ModbusBridgeEntity(CoordinatorEntity):
             if not await self._api_client.async_write_register(self._register, value_to_write):
                 return False
 
-            # Show the new value immediately, but treat it as provisional: only the
-            # next poll proves what the inverter actually stored.
             registers[self._register] = value_to_write
             self.async_write_ha_state()
 
-        # Requested outside the lock; the coordinator debounces concurrent requests.
-        await self.coordinator.async_request_refresh()
+            # The client confirmed the write and re-read the affected settings block
+            # on the same connection, so publish that rather than asking for a fresh
+            # poll. A poll re-reads every register block, which kept the service call
+            # blocked for tens of seconds after the inverter had already applied the
+            # change. Publishing inside the lock also means the next write on a shared
+            # register composes from confirmed values instead of the local guess.
+            self.coordinator.async_set_updated_data(self._api_client.get_cached_data())
+
         return True
 
     @callback

--- a/tests/test_entity_write.py
+++ b/tests/test_entity_write.py
@@ -18,9 +18,19 @@ ENTRY_ID = "test_entry_id"
 
 @pytest.fixture
 def api_client():
-    """Mock API client that reports successful writes."""
+    """Mock API client that confirms writes and caches them like the real one."""
+    cache = {"hold": {}, "input": {}, "battery": {}}
+
+    async def confirmed_write(register, value):
+        cache["hold"][register] = value
+        return True
+
     client = AsyncMock()
-    client.async_write_register = AsyncMock(return_value=True)
+    client.async_write_register = AsyncMock(side_effect=confirmed_write)
+    client.get_cached_data = MagicMock(
+        side_effect=lambda: {key: dict(values) for key, values in cache.items()}
+    )
+    client.cache = cache
     return client
 
 
@@ -40,6 +50,10 @@ def coordinator():
     coord = MagicMock()
     coord.data = {"hold": {}, "input": {}}
     coord.async_request_refresh = AsyncMock()
+    # Mirrors Home Assistant: published data replaces what entities read.
+    coord.async_set_updated_data = MagicMock(
+        side_effect=lambda data: setattr(coord, "data", data)
+    )
     coord.hass = MagicMock()
     coord.hass.data = {DOMAIN: {ENTRY_ID: {"write_lock": asyncio.Lock()}}}
     return coord
@@ -197,8 +211,8 @@ class TestSharedWritePath:
     """Behaviour of ModbusBridgeEntity._async_write_register."""
 
     @pytest.mark.asyncio
-    async def test_write_updates_cache_and_requests_refresh(self, coordinator, entry, api_client):
-        """A successful write is shown immediately and then re-checked against the inverter."""
+    async def test_write_publishes_what_the_inverter_confirmed(self, coordinator, entry, api_client):
+        """The client already confirmed the write, so its cache is published."""
         coordinator.data["hold"][21] = 0
         entity = make_switch(coordinator, entry, api_client, SWITCH_A_DESC)
 
@@ -207,7 +221,17 @@ class TestSharedWritePath:
         api_client.async_write_register.assert_awaited_once_with(21, 1)
         assert coordinator.data["hold"][21] == 1
         entity.async_write_ha_state.assert_called_once()
-        coordinator.async_request_refresh.assert_awaited_once()
+        coordinator.async_set_updated_data.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_write_does_not_wait_for_a_poll(self, coordinator, entry, api_client):
+        """Issue #154: the refresh re-read every block and blocked the call ~30 s."""
+        coordinator.data["hold"][21] = 0
+        entity = make_switch(coordinator, entry, api_client, SWITCH_A_DESC)
+
+        await entity.async_turn_on()
+
+        coordinator.async_request_refresh.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_failed_write_leaves_cache_untouched(self, coordinator, entry, api_client):
@@ -220,7 +244,7 @@ class TestSharedWritePath:
 
         assert coordinator.data["hold"][21] == 0
         entity.async_write_ha_state.assert_not_called()
-        coordinator.async_request_refresh.assert_not_awaited()
+        coordinator.async_set_updated_data.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_missing_api_client_is_reported_not_raised(self, coordinator, entry):
@@ -229,7 +253,7 @@ class TestSharedWritePath:
 
         await entity.async_turn_on()
 
-        coordinator.async_request_refresh.assert_not_awaited()
+        coordinator.async_set_updated_data.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_concurrent_writes_on_shared_register_do_not_clobber(
@@ -247,6 +271,7 @@ class TestSharedWritePath:
             # Force the two writes to overlap if they are not serialised.
             await asyncio.sleep(0)
             written.append((register, value))
+            api_client.cache["hold"][register] = value
             return True
 
         api_client.async_write_register = AsyncMock(side_effect=slow_write)

--- a/tests/test_modbus_client.py
+++ b/tests/test_modbus_client.py
@@ -418,10 +418,12 @@ class TestLxpModbusApiClient:
                 mock_response_class.return_value = mock_response
                 
                 result = await client.async_write_register(100, 500)
-                
+
                 assert result is True
-                writer.write.assert_called_once()
-                writer.drain.assert_called_once()
+                # The write itself, then the settings block re-read that confirms it
+                # on the same connection.
+                assert writer.write.call_count == 2
+                assert writer.drain.call_count == 2
 
     @pytest.mark.asyncio
     async def test_async_write_register_failure(self, client):

--- a/tests/test_poll_cadence.py
+++ b/tests/test_poll_cadence.py
@@ -73,8 +73,11 @@ class TestHoldPollCadence:
         assert decisions == [False] * (HOLD_REGISTER_POLL_EVERY - 1)
 
     @pytest.mark.asyncio
-    async def test_successful_write_requests_a_hold_refresh(self, ):
-        """The client itself flags the refresh, so every platform benefits."""
+    async def test_write_whose_confirmation_read_fails_requests_a_hold_refresh(self):
+        """A write is normally confirmed inline; the cadence is the fallback.
+
+        See test_write_confirmation.py for the inline path.
+        """
         client = make_client(connection_retries=1)
         reader, writer = AsyncMock(spec=asyncio.StreamReader), AsyncMock(spec=asyncio.StreamWriter)
         writer.write = MagicMock()
@@ -89,6 +92,8 @@ class TestHoldPollCadence:
                     packet_error=False, device_function=6, exception=0,
                     parsed_values_dictionary={100: 500},
                 )
+                # The mocked response is not a valid read reply, so the inline
+                # confirmation read comes back empty.
                 assert await client.async_write_register(100, 500) is True
 
         assert client._force_hold_poll is True

--- a/tests/test_write_confirmation.py
+++ b/tests/test_write_confirmation.py
@@ -1,0 +1,186 @@
+"""Tests for how a write is confirmed against the inverter.
+
+Issue #154: on v1.1.0-beta.1 a switch took ~30 s to settle. The inverter had the
+new value within a second, but the confirmation went through a full coordinator
+refresh, which re-reads every input block and then every settings block. The
+service call stayed blocked for the whole poll, so automations serialised at
+~30 s per step.
+
+The write acknowledgement already echoes the stored value, and the settings block
+that changed is one request on the connection the write just used.
+"""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from custom_components.lxp_modbus.classes.modbus_client import LxpModbusApiClient
+
+
+def make_client(**kwargs):
+    return LxpModbusApiClient(
+        "192.0.2.1", 8000, "BA0000000A", "0000000001", asyncio.Lock(), **kwargs
+    )
+
+
+@pytest.fixture
+def reader_writer():
+    reader = AsyncMock(spec=asyncio.StreamReader)
+    writer = AsyncMock(spec=asyncio.StreamWriter)
+    writer.write = MagicMock()
+    reader.read = AsyncMock(return_value=b"\x00" * 76)
+    return reader, writer
+
+
+def accepted_response(register, value):
+    """A parsed acknowledgement echoing what the inverter stored."""
+    return MagicMock(
+        packet_error=False,
+        device_function=6,
+        exception=0,
+        register=register,
+        parsed_values_dictionary={register: value},
+        info="",
+    )
+
+
+async def write_with(client, reader, writer, register, value, reread=None):
+    """Run a write against mocked transport, stubbing the post-write re-read."""
+    with patch('asyncio.open_connection', return_value=(reader, writer)):
+        with patch('custom_components.lxp_modbus.classes.modbus_client.LxpResponse',
+                   return_value=accepted_response(register, value)):
+            with patch.object(client, 'async_request_registers',
+                              AsyncMock(return_value=reread if reread is not None else {})) as read:
+                result = await client.async_write_register(register, value)
+    return result, read
+
+
+class TestConfirmationCost:
+    """Confirming a write must not cost a full poll."""
+
+    @pytest.mark.asyncio
+    async def test_only_the_affected_settings_block_is_re_read(self, reader_writer):
+        """One request, not one per block: the block containing the register."""
+        reader, writer = reader_writer
+        client = make_client(connection_retries=1, block_size=40)
+
+        result, read = await write_with(client, reader, writer, 21, 62404, reread={21: 62404})
+
+        assert result is True
+        read.assert_awaited_once()
+        _writer, _reader, start, request_type, function_code = read.await_args.args
+        assert (start, request_type, function_code) == (0, "hold", 3)
+
+    @pytest.mark.asyncio
+    async def test_re_read_starts_at_the_block_holding_the_register(self, reader_writer):
+        """Blocks are aligned the same way the poller aligns them."""
+        reader, writer = reader_writer
+        client = make_client(connection_retries=1, block_size=125)
+
+        _result, read = await write_with(client, reader, writer, 261, 80, reread={261: 80})
+
+        assert read.await_args.args[2] == 250
+
+    @pytest.mark.asyncio
+    async def test_re_read_uses_the_write_connection(self, reader_writer):
+        """A second connection would cost the dongle another handshake."""
+        reader, writer = reader_writer
+        client = make_client(connection_retries=1)
+
+        with patch('asyncio.open_connection', return_value=(reader, writer)) as connect:
+            with patch('custom_components.lxp_modbus.classes.modbus_client.LxpResponse',
+                       return_value=accepted_response(21, 1)):
+                with patch.object(client, 'async_request_registers',
+                                  AsyncMock(return_value={21: 1})):
+                    await client.async_write_register(21, 1)
+
+        assert connect.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_confirmed_write_does_not_force_a_full_settings_poll(self, reader_writer):
+        """The value is already known, so the next poll keeps its normal shape."""
+        reader, writer = reader_writer
+        client = make_client(connection_retries=1)
+        client._force_hold_poll = False
+
+        await write_with(client, reader, writer, 21, 62404, reread={21: 62404})
+
+        assert client._force_hold_poll is False
+
+
+class TestConfirmedValueReachesTheCache:
+    """Whatever the inverter reports has to be what entities read."""
+
+    @pytest.mark.asyncio
+    async def test_re_read_values_are_cached(self, reader_writer):
+        """A write can move sibling settings, so the whole block is kept."""
+        reader, writer = reader_writer
+        client = make_client(connection_retries=1)
+
+        await write_with(client, reader, writer, 21, 62404, reread={21: 62404, 22: 7})
+
+        assert client.get_cached_data()["hold"] == {21: 62404, 22: 7}
+
+    @pytest.mark.asyncio
+    async def test_acknowledged_value_is_cached_without_the_re_read(self, reader_writer):
+        """The acknowledgement echoes the stored value, so it stands on its own."""
+        reader, writer = reader_writer
+        client = make_client(connection_retries=1)
+
+        await write_with(client, reader, writer, 21, 62404, reread={})
+
+        assert client.get_cached_data()["hold"][21] == 62404
+
+    @pytest.mark.asyncio
+    async def test_failed_re_read_falls_back_to_the_next_poll(self, reader_writer):
+        """A re-read that returns nothing must not leave siblings unchecked."""
+        reader, writer = reader_writer
+        client = make_client(connection_retries=1)
+        client._force_hold_poll = False
+
+        await write_with(client, reader, writer, 21, 62404, reread={})
+
+        assert client._force_hold_poll is True
+
+    @pytest.mark.asyncio
+    async def test_re_read_timeout_does_not_undo_a_confirmed_write(self, reader_writer):
+        """The inverter accepted it; a failed follow-up read is not a write failure."""
+        reader, writer = reader_writer
+        client = make_client(connection_retries=1)
+
+        with patch('asyncio.open_connection', return_value=(reader, writer)):
+            with patch('custom_components.lxp_modbus.classes.modbus_client.LxpResponse',
+                       return_value=accepted_response(21, 1)):
+                with patch.object(client, 'async_request_registers',
+                                  AsyncMock(side_effect=asyncio.TimeoutError)):
+                    result = await client.async_write_register(21, 1)
+
+        assert result is True
+        assert client._force_hold_poll is True
+
+    @pytest.mark.asyncio
+    async def test_rejected_write_is_not_cached(self, reader_writer):
+        """Only confirmed values may reach the cache."""
+        reader, writer = reader_writer
+        client = make_client(connection_retries=1)
+        mismatch = MagicMock(
+            packet_error=False, device_function=6, exception=0, register=21,
+            parsed_values_dictionary={21: 0}, info="",
+        )
+
+        with patch('asyncio.open_connection', return_value=(reader, writer)):
+            with patch('custom_components.lxp_modbus.classes.modbus_client.LxpResponse',
+                       return_value=mismatch):
+                with patch.object(client, 'async_request_registers', AsyncMock()) as read:
+                    assert await client.async_write_register(21, 1) is False
+
+        assert client.get_cached_data()["hold"] == {}
+        read.assert_not_awaited()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #154.

## What was happening

A `switch.turn_on` on register 21 took ~30 s to settle, while the LuxPower portal showed the change within a second. From the reporter's log:

```
17:55:20.474  poll starts (holds the shared connection lock)
17:55:33.963  poll ends
17:55:33.970  Write attempt 1/3 for register 21 with value 62404
17:55:35.612  Successfully wrote register 21          <- inverter has it, 4.4 s in
17:55:35.612  forced refresh starts
   35.6 -> 49.8   input 0-749, 19 blocks, 14.2 s      <- not needed to confirm a setting
   49.8 -> 01.1   hold  0-749, 19 blocks, 11.2 s      <- only one block was needed
17:56:01.116  Finished fetching ... 25.504 seconds
```

The write handler confirmed by awaiting `coordinator.async_request_refresh()`, and a refresh re-reads every input block and then every settings block. The service call stayed blocked for all of it, so automation steps serialised at ~30 s each.

The reporter's reading was that the post-write settings re-read never fired. It does fire — `request_hold_refresh()` works, and the hold blocks are visible in the log. The 30 s is the duration of the poll it was hitched to, not the settings cadence.

## What this changes

Confirm where the evidence already is, instead of polling for it:

- The write acknowledgement echoes the value the inverter stored (it is already checked against what was sent), so it is cached as confirmed straight away.
- The settings block containing the register is re-read on the connection the write just used — one request instead of one per block — so siblings the inverter derives from the write are still caught.
- The entity publishes that cache via `async_set_updated_data` rather than requesting a poll. Publishing inside the write lock also means the next write on a shared register composes from confirmed values rather than the local guess.

The forced settings poll stays as the fallback for when the inline re-read comes back empty or times out; a failed follow-up read never turns a confirmed write into a failure.

Confirmation drops from a full poll (25 s on the reporter's dongle, ~14 s on a default `register_block_size`) to a single register block, roughly 0.7 s.

## Tests

`tests/test_write_confirmation.py` covers the new path: only the affected block is re-read, it is aligned the way the poller aligns blocks, it reuses the write connection, the confirmed value reaches the cache with and without the re-read, a failed re-read falls back to the next poll without undoing the write, and a rejected write is never cached. `tests/test_entity_write.py` gains a regression test that a write no longer waits on a poll.

290 tests pass.

## Note for the reporter, unrelated to this fix

The log shows `register_block_size` 40, which is `LEGACY_REGISTER_BLOCK_SIZE`; the default is 125. That is why a poll takes ~13.5 s rather than ~4.5 s. Worth raising separately.