### PR TITLE
feat: add AC CT direction switch

### DIFF
--- a/custom_components/lxp_modbus/entity_descriptions/switch_types.py
+++ b/custom_components/lxp_modbus/entity_descriptions/switch_types.py
@@ -207,6 +207,19 @@ SWITCH_TYPES = [
     },
     # Register 179: H_FUNCTION_ENABLE_4
     {
+        "name": "AC CT Direction Reversed",
+        "register": H_FUNCTION_ENABLE_4, # 179
+        "register_type": "hold",
+        "extract": lambda reg: get_bits(reg, 0, 1),
+        "compose": lambda orig, value: set_bits(orig, 0, 1, value),
+        "icon": "mdi:swap-horizontal",
+        "device_class": "switch",
+        "enabled": True,
+        "visible": True,
+        "master_only": True,
+        "device_group": "Grid",
+    },
+    {
         "name": "Volt-Watt Function",
         "register": H_FUNCTION_ENABLE_4, # 179
         "register_type": "hold",


### PR DESCRIPTION
Adds an AC CT Direction Reversed switch.
The switch is placed in the Grid device group.
Tested on SNA6000
<img width="1270" height="472" alt="image" src="https://github.com/user-attachments/assets/4dcb0296-5df6-46e8-9847-bda18f3ef34d" />
